### PR TITLE
Feature/task 31 adiciona dependencia nanoID

### DIFF
--- a/apps/avaliaif-backend/pom.xml
+++ b/apps/avaliaif-backend/pom.xml
@@ -30,6 +30,12 @@
 	<properties>
 		<java.version>21</java.version>
 	</properties>
+	<repositories>
+		<repository>
+			<id>jitpack.io</id>
+			<url>https://jitpack.io</url>
+		</repository>
+	</repositories>
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -73,6 +79,11 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>co.wosher</groupId>
+			<artifactId>jnanoid-enhanced</artifactId>
+			<version>main-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
 Objetivo
Adiciona a dependência `jnanoid-enhanced` para possibilitar a geração de NanoIDs que serão utilizados nas colunas `public_id` das tabelas do sistema.
- Task: #31
